### PR TITLE
Add some domains for YouTube image service.

### DIFF
--- a/Surge/Surge 3/Provider/Media/YouTube.list
+++ b/Surge/Surge 3/Provider/Media/YouTube.list
@@ -5,3 +5,5 @@ DOMAIN-KEYWORD,youtube
 DOMAIN-SUFFIX,googlevideo.com
 DOMAIN-SUFFIX,gvt2.com
 DOMAIN-SUFFIX,youtu.be
+DOMAIN-SUFFIX,ytimg.com
+DOMAIN,yt3.ggpht.com


### PR DESCRIPTION
YouTube images, like thumbnails and icons, come from "ytimg.com" and "yt3.ggpht.com".